### PR TITLE
Issue #96: Remove links for which the equivalent on drupal.org takes to a tutorial page created for the Examples for Developers project

### DIFF
--- a/simpletest_example/tests/simpletest_example.test
+++ b/simpletest_example/tests/simpletest_example.test
@@ -1,8 +1,7 @@
 <?php
 /**
  * @file
- * An example of simpletest tests to accompany the tutorial at
- * http://DOCUMENTATION_PENDING/node/890654.
+ * An example of simpletest tests.
  */
 
 /**


### PR DESCRIPTION
Fixes #96